### PR TITLE
Fix cursor bugs

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -50,6 +50,6 @@ impl Editor {
     /// Go to next cursor
     #[inline]
     pub fn next_cursor(&mut self) {
-        self.current_cursor = (self.current_cursor + 1) % (self.cursors.len() as u8);
+        self.current_cursor = (self.current_cursor.wrapping_add(1)) % (self.cursors.len() as u8);
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -52,4 +52,15 @@ impl Editor {
     pub fn next_cursor(&mut self) {
         self.current_cursor = (self.current_cursor.wrapping_add(1)) % (self.cursors.len() as u8);
     }
+
+    /// Go to previous cursor
+    #[inline]
+    pub fn prev_cursor(&mut self) {
+        if self.current_cursor != 0 {
+            self.current_cursor -= 1;
+        }
+        else {
+            self.current_cursor = self.cursors.len() as u8;
+        }
+    }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -172,13 +172,23 @@ impl Editor {
                     }
                     Char('b') => {
                         // Branch cursor
-                        let cursor = self.cursor().clone();
-                        self.cursors.push(cursor);
+                        if self.cursors.len() < 255 {
+                            let cursor = self.cursor().clone();
+                            self.cursors.push(cursor);
+                        }
+                        else {
+                            self.status_bar.msg = format!("At max 255 cursors");
+                        }
                     }
                     Char('B') => {
                         // Delete cursor
-                        self.cursors.remove(self.current_cursor as usize);
-                        self.next_cursor();
+                        if self.cursors.len() > 1 {
+                            self.cursors.remove(self.current_cursor as usize);
+                            self.next_cursor();
+                        }
+                        else {
+                            self.status_bar.msg = format!("No other cursors!");
+                        }
                     }
                     Char('t') => {
                         let ch = self.get_char();

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -174,7 +174,8 @@ impl Editor {
                         // Branch cursor
                         if self.cursors.len() < 255 {
                             let cursor = self.cursor().clone();
-                            self.cursors.push(cursor);
+                            self.cursors.insert(self.current_cursor as usize, cursor);
+                            self.next_cursor();
                         }
                         else {
                             self.status_bar.msg = format!("At max 255 cursors");
@@ -184,7 +185,7 @@ impl Editor {
                         // Delete cursor
                         if self.cursors.len() > 1 {
                             self.cursors.remove(self.current_cursor as usize);
-                            self.next_cursor();
+                            self.prev_cursor();
                         }
                         else {
                             self.status_bar.msg = format!("No other cursors!");


### PR DESCRIPTION
The first commit fixes some division by zero errors, and a technically illegal wrapping add.

The second commit tries to make `b` and `B` work a bit more sensibly. The previous behavior was very non-predictable as a user and almost certainly not what was intended. A good way to see this is to make a 10 line file, start at the top and enter `bj` repeatedly until you reach the bottom, then enter `B` repeatedly until you delete all but one cursor.

I haven't used this sort of cursor functionality before, so it's entirely possible the new behavior is also not ideal. The idea behind it was vaguely that users could use them as stacks of cursors holding places to return to. Do any editors have similar functionality that I should try out?
