### PR TITLE
Fix deletion (removes InsertMode::Append)

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -21,4 +21,16 @@ impl Editor {
 
         self.hint();
     }
+
+    #[inline]
+    pub fn backspace(&mut self) {
+        let previous = self.previous(1);
+        if let Some(p) = previous {
+            self.goto(p);
+            self.delete();
+        }
+        else {
+            self.status_bar.msg = format!("Can't delete file start");
+        }
+    }
 }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,19 +1,18 @@
 use editor::Editor;
 use redraw::RedrawTask;
 use buffer::Buffer;
+use cursor::Cursor;
 
 impl Editor {
     /// Delete a character
     #[inline]
     pub fn delete(&mut self) {
-        let (x, y) = self.pos();
-        if x == 0 {
-            if y != 0 {
-                let s = self.buffer.remove_line(y);
-                self.buffer[y - 1].push_str(&s);
-                let len = self.buffer[y - 1].len();
-                self.goto((len, y - 1));
-                self.redraw_task = RedrawTask::Lines(y..y + 1);
+        let &Cursor{ x, y, ..} = self.cursor();
+        if x == self.buffer[y].len() {
+            if y < self.buffer.len() - 1 {
+                let s = self.buffer.remove_line(y + 1);
+                self.buffer[y].push_str(&s);
+                self.redraw_task = RedrawTask::Lines(y..y+1);
             }
         } else if x < self.buffer[y].len() {
             self.buffer[y].remove(x);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -27,6 +27,10 @@ impl Editor {
 
             match mode {
                 Primitive(Prompt) => self.prompt = String::new(),
+                Primitive(Insert(_)) => {
+                    let left = self.left(1);
+                    self.goto(left);
+                }
                 _ => {}
             }
             self.cursor_mut().mode = Mode::Command(CommandMode::Normal);
@@ -66,9 +70,11 @@ impl Editor {
 
                     }
                     Char('a') => {
+                        let pos = self.right(1, false);
+                        self.goto( pos );
                         self.cursor_mut().mode =
                             Mode::Primitive(PrimitiveMode::Insert(InsertOptions {
-                                mode: InsertMode::Append,
+                                mode: InsertMode::Insert,
                             }));
 
                     }
@@ -103,7 +109,7 @@ impl Editor {
                         mov = true;
                     }
                     Char('l') => {
-                        let right = self.right(n);
+                        let right = self.right(n, true);
                         self.goto(right);
                         mov = true;
                     }
@@ -117,8 +123,16 @@ impl Editor {
                         self.goto(up);
                         mov = true;
                     }
-                    Char('x') => self.delete(),
-                    Char('X') => self.backspace(),
+                    Char('x') => {
+                        self.delete();
+                        let bounded = self.bound(self.pos(), true);
+                        self.goto(bounded);
+                    }
+                    Char('X') => {
+                        self.backspace();
+                        let bounded = self.bound(self.pos(), true);
+                        self.goto(bounded);
+                    }
                     Char('L') => {
                         let ln_end = (self.buffer[self.y()].len(), self.y());
                         self.goto(ln_end);

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -118,13 +118,7 @@ impl Editor {
                         mov = true;
                     }
                     Char('x') => self.delete(),
-                    Char('X') => {
-                        let previous = self.previous(1);
-                        if let Some(p) = previous {
-                            self.goto(p);
-                        }
-                        self.delete();
-                    }
+                    Char('X') => self.backspace(),
                     Char('L') => {
                         let ln_end = (self.buffer[self.y()].len(), self.y());
                         self.goto(ln_end);

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -167,9 +167,6 @@ impl Editor {
 
         let w = self.window.width();
 
-        pos_x += self.delta();
-
-
         if self.options.line_marker {
             self.window.rect(0,
                              (pos_y - self.scroll_y) as i32 * 16,

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -71,33 +71,7 @@ impl Editor {
                         self.redraw_task = RedrawTask::LinesAfter(y);
                         self.goto((begin, y + 1));
                     }
-                    Key::Backspace => {
-                        // NEEDS REWRITE {
-                        // Backspace
-                        let del = if self.buffer[y].len() == 0 {
-                            1
-                        } else if d == 0 && x == 0 {
-                            self.cursor_mut().mode =
-                                Mode::Primitive(PrimitiveMode::Insert(InsertOptions {
-                                    mode: InsertMode::Append,
-                                }));
-                            1
-
-                        } else {
-                            1 - d
-                        };
-
-                        let prev = self.previous(del);
-                        if let Some((x, y)) = prev {
-                            // if self.x() != 0 || self.y() != 0 {
-                            self.goto((x + d, y));
-                            self.delete();
-                            // }
-                        }
-
-                        // }
-
-                    }
+                    Key::Backspace => self.backspace(),
                     Key::Char(c) => {
                         self.buffer[y].insert(x + d, c);
 

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -10,8 +10,6 @@ use std::iter::FromIterator;
 #[derive(Clone, PartialEq, Copy)]
 /// The type of the insert mode
 pub enum InsertMode {
-    /// Append text (after the cursor)
-    Append,
     /// Insert text (before the cursor)
     Insert,
     /// Replace text (on the cursor)
@@ -27,35 +25,15 @@ pub struct InsertOptions {
 }
 
 impl Editor {
-    /// Delta x, i.e. the cursors visual position's x coordinate relative to the cursors actual
-    /// position. For example append will append character after the cursor, but visually it have
-    /// delta x = 1, so it will look like normal insert mode, except when going back to normal
-    /// mode, the cursor will move back (visually), because the delta x will drop to 0.
-    pub fn delta(&self) -> usize {
-        let (x, y) = self.pos();
-        match self.cursor().mode {
-            _ if x > self.buffer[y].len() => {
-                0
-            }
-            Mode::Primitive(PrimitiveMode::Insert(InsertOptions { mode: InsertMode::Append }))
-                if x == self.buffer[y].len() => 0,
-
-            Mode::Primitive(PrimitiveMode::Insert(InsertOptions { mode: InsertMode::Append })) => 1,
-            _ => 0,
-        }
-    }
-
     /// Insert text under the current cursor.
     pub fn insert(&mut self, k: Key, InsertOptions { mode }: InsertOptions) {
         let (mut x, mut y) = self.pos();
         match mode {
-            InsertMode::Insert | InsertMode::Append => {
-                let d = self.delta();
-
-                match k {
+            InsertMode::Insert => {
+               match k {
                     Key::Char('\n') => {
-                        let first_part  = self.buffer[y][..x + d].to_owned();
-                        let second_part = self.buffer[y][x + d..].to_owned();
+                        let first_part  = self.buffer[y][..x].to_owned();
+                        let second_part = self.buffer[y][x..].to_owned();
 
                         self.buffer[y] = first_part;
 
@@ -73,21 +51,10 @@ impl Editor {
                     }
                     Key::Backspace => self.backspace(),
                     Key::Char(c) => {
-                        self.buffer[y].insert(x + d, c);
-
-                        // TODO: Are there a better way than switching?
-                        match mode {
-                            InsertMode::Insert if x + 1 == self.buffer[y].len() => {
-                                self.cursor_mut().mode =
-                                    Mode::Primitive(PrimitiveMode::Insert(InsertOptions {
-                                        mode: InsertMode::Append,
-                                    }));
-                            }
-                            _ => {}
-                        }
+                        self.buffer[y].insert(x, c);
 
                         self.redraw_task = RedrawTask::Lines(y..y + 1);
-                        let right = self.right(1);
+                        let right = self.right(1, false);
                         self.goto(right);
                     }
                     _ => {}

--- a/src/motion.rs
+++ b/src/motion.rs
@@ -19,7 +19,7 @@ impl Editor {
 
         match cmd.key {
             Char('h') => Some(self.left(n.d())),
-            Char('l') => Some(self.right(n.d())),
+            Char('l') => Some(self.right(n.d(), true)),
             Char('j') => Some(self.down(n.d())),
             Char('k') => Some(self.up(n.d())),
             Char('g') => Some((0, n.or(1) - 1)),

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -9,7 +9,8 @@ impl Editor {
         self.cursor_mut().x = x;
     }
 
-    /// Get the previous position, i.e. the position before the cursor (*not* left to the cursor)
+    /// Get the previous position, i.e. the position before the cursor (*not* left to the cursor).
+    /// Includes newline positions.
     #[inline]
     pub fn previous(&self, n: usize) -> Option<(usize, usize)> {
         self.before(n, self.pos())
@@ -53,7 +54,8 @@ impl Editor {
         // }
     }
 
-    /// Get the position before a given position, i.e. a generalisation .before()
+    /// Get the position before a given position, i.e. a generalisation .before(). Includes
+    /// newline positions.
     #[inline]
     pub fn before(&self, n: usize, (x, y): (usize, usize)) -> Option<(usize, usize)> {
         if x >= n {
@@ -62,7 +64,7 @@ impl Editor {
             if y == 0 {
                 None
             } else {
-                let mut mv = n - x;
+                let mut mv = n - x - 1;
                 let mut ry = y - 1;
 
                 loop {

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -86,8 +86,8 @@ impl Editor {
 
     /// Get the position of the character right to the cursor (horizontally bounded)
     #[inline]
-    pub fn right(&self, n: usize) -> (usize, usize) {
-        self.bound_hor((self.x() + n, self.y()))
+    pub fn right(&self, n: usize, tight: bool) -> (usize, usize) {
+        self.bound_hor((self.x() + n, self.y()), tight)
     }
     /// Get the position of the character right to the cursor (unbounded)
     #[inline]

--- a/src/position.rs
+++ b/src/position.rs
@@ -11,7 +11,7 @@ impl Editor {
     #[inline]
     pub fn pos(&self) -> (usize, usize) {
         let cursor = self.cursor();
-        self.bound((cursor.x, cursor.y))
+        self.bound((cursor.x, cursor.y), false)
     }
 
     #[inline]
@@ -28,7 +28,7 @@ impl Editor {
 
     /// Convert a position value to a bounded position value
     #[inline]
-    pub fn bound(&self, (x, mut y): (usize, usize)) -> (usize, usize) {
+    pub fn bound(&self, (x, mut y): (usize, usize), tight: bool) -> (usize, usize) {
 
 
         y = if y >= self.buffer.len() {
@@ -37,7 +37,7 @@ impl Editor {
             y
         };
 
-        let ln = self.buffer[y].len();
+        let ln = self.buffer[y].len() + if tight {0} else {1};
         if x >= ln {
             if ln == 0 {
                 (0, y)
@@ -52,9 +52,8 @@ impl Editor {
     /// Bound horizontally, i.e. don't change the vertical axis only make sure that the horizontal
     /// axis is bounded.
     #[inline]
-    pub fn bound_hor(&self, (x, y): (usize, usize)) -> (usize, usize) {
-
-        (self.bound((x, y)).0, y)
+    pub fn bound_hor(&self, (x, y): (usize, usize), tight: bool) -> (usize, usize) {
+        (self.bound((x, y), tight).0, y)
     }
     /// Bound vertically, i.e. don't change the horizontal axis only make sure that the vertical
     /// axis is bounded.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -9,7 +9,7 @@ impl Editor {
     /// motion's position are removed.
     pub fn remove_rb<'a>(&mut self, (x, y): (isize, isize)) {
         if y == self.y() as isize {
-            let (x, y) = self.bound((x as usize, y as usize));
+            let (x, y) = self.bound((x as usize, y as usize), true);
             // Single line mode
             let (a, b) = if self.x() > x {
                 (x, self.x())
@@ -18,7 +18,7 @@ impl Editor {
             };
             for _ in self.buffer[y].drain(a..b) {}
         } else {
-            let (_, y) = self.bound((x as usize, y as usize));
+            let (_, y) = self.bound((x as usize, y as usize), true);
             // Full line mode
             let (a, b) = if self.y() < y {
                 (self.y(), y)


### PR DESCRIPTION
Fixes:
- Delete works as expected at the start of lines
- Backspace works as expected at the start of lines
- line 1: "abc", line 2: "abcdef", at the end of line 1 do "aa<backspace>", exit insert mode, go down. Now we end up in the right place.

Changes:
- Exiting insert mode always (unless at the start of a line) moves back 1 character now, matching vim.

This completely deletes Append Mode from the code base. Append mode had some weird characteristics, such as your position was the same if you were in the 0th column of a new line, or the 1st column. From an architecture point of view having the extra insert mode that acted almost identically to the user seemed unnecessary. That said, if there are good reasons for it that I'm unaware of, this code should not be merged.
