### PR TITLE
Fix next ocur

### DIFF
--- a/src/caret/movement.rs
+++ b/src/caret/movement.rs
@@ -140,7 +140,7 @@ impl Editor {
     /// Get n'th next ocurrence of a given charecter (relatively to the cursor)
     pub fn next_ocur(&self, c: char, n: usize) -> Option<usize> {
         let mut dn = 0;
-        let mut x      = self.x();
+        let mut x  = self.x();
 
         for (i, ch) in self.buffers.current_buffer()[self.y()].chars().skip(x).enumerate() {
             if ch == c {

--- a/src/caret/movement.rs
+++ b/src/caret/movement.rs
@@ -140,15 +140,14 @@ impl Editor {
     /// Get n'th next ocurrence of a given charecter (relatively to the cursor)
     pub fn next_ocur(&self, c: char, n: usize) -> Option<usize> {
         let mut dn = 0;
-        let x      = self.x();
+        let mut x      = self.x();
 
-        for ch in self.buffers.current_buffer()[self.y()].chars().skip(x) {
-            if dn == n {
-                if ch == c {
-                    dn += 1;
-                    if dn == n {
-                        return Some(x);
-                    }
+        for (i, ch) in self.buffers.current_buffer()[self.y()].chars().skip(x).enumerate() {
+            if ch == c {
+                dn += 1;
+                if dn == n {
+                    x += i;
+                    return Some(x);
                 }
             }
         }


### PR DESCRIPTION
Fixes #44.

Removes an extraneous if that seemingly never fires and updates the position of x based on the next occurrence.

This doesn't work multiline but I wanted some feedback on it to see if this was the right direction.
