### PR TITLE
find next occurrence when current cursor is equal to the searched char

### DIFF
--- a/src/caret/movement.rs
+++ b/src/caret/movement.rs
@@ -144,10 +144,12 @@ impl Editor {
 
         for (i, ch) in self.buffers.current_buffer()[self.y()].chars().skip(x).enumerate() {
             if ch == c {
-                dn += 1;
-                if dn == n {
-                    x += i;
-                    return Some(x);
+                if i > 0 {
+                    dn += 1;
+                    if dn == n {
+                        x += i;
+                        return Some(x);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #48.

Checks to make sure we're not on the current occurrence of the character.
