### PR TITLE
Rewrite argument handling, add read-only mode

### DIFF
--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -126,10 +126,16 @@ impl Editor {
                 }
             },
             Write { path } => {
-                self.status_bar.msg = match self.write(path) {
-                    FileStatus::NotFound => format!("File {} could not be opened", path),
-                    FileStatus::Ok => format!("File {} written", path),
-                    FileStatus::Other => format!("Couldn't write {}", path),
+                if self.options.get("readonly") == Some(true) {
+                    // TODO: add override (w!)
+                    self.status_bar.msg = format!("File {} is opened in readonly mode", path)
+                }
+                else {
+                    self.status_bar.msg = match self.write(path) {
+                        FileStatus::NotFound => format!("File {} could not be opened", path),
+                        FileStatus::Ok => format!("File {} written", path),
+                        FileStatus::Other => format!("Couldn't write {}", path),
+                    }
                 }
             },
             ListBuffers => {

--- a/src/state/editor.rs
+++ b/src/state/editor.rs
@@ -248,31 +248,32 @@ impl Editor {
                     break;
                 }
                 _ => {
-                    let mut arg_chars = arg.chars();
-                    if arg_chars.next() == Some('-') {
-                        for ch in arg_chars {
-                            match ch {
-                                'R' => {
-                                    unimplemented!();
-                                    /*
-                                    match editor.options.set("readonly") {
-                                        Ok(_) => debugln!(editor, "Set readonly mode"),
-                                        Err(_) => println!("Could not set readonly mode") 
+                    {
+                        let mut arg_chars = arg.chars();
+                        if arg_chars.next() == Some('-') {
+                            for ch in arg_chars {
+                                match ch {
+                                    'R' => {
+                                        match editor.options.set("readonly") {
+                                            Ok(_) => debugln!(editor, "Set readonly mode"),
+                                            Err(_) => println!("Could not set readonly mode") 
+                                        }
+                                    },
+                                    'h' => {
+                                        println!("{}", HELP);
+                                        return;
+                                    },
+                                    _ => {
+                                        unimplemented!();
                                     }
-                                    */
-                                },
-                                'h' => {
-                                    println!("{}", HELP);
-                                    return;
-                                },
-                                _ => {
-                                    unimplemented!();
                                 }
                             }
+
+                            continue;
                         }
                     }
 
-                    files.push(arg.clone());
+                    files.push(arg);
                 }
             }
         }

--- a/src/state/editor.rs
+++ b/src/state/editor.rs
@@ -208,28 +208,71 @@ impl Editor {
         };
 
         let mut files: Vec<String> = Vec::new();
+        
+        let mut args_iter = args().skip(1).peekable();
+        loop {
+            let arg = match args_iter.next() {
+                Some(x) => x,
+                None => break
+            };
 
-        for arg in args().skip(1) {
             match arg.as_str() {
                 "--version" => {
                     println!("Sodium {}", option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"));
                     return;
                 },
-                "--help" | "-h" => {
+                "--help" => {
                     println!("{}", HELP);
                     return;
-                }
-                "-R" => {
+                },
+                "-u" => {
                     unimplemented!();
                     /*
-                    match editor.options.set("readonly") {
-                        Ok(_) => debugln!(editor, "Set readonly mode"),
-                        Err(_) => println!("Could not set readonly mode") 
+                    match args_iter.peek() {
+                        Some(config) => {
+                            // this is the config file to use for this session
+                            println!("{}", config);
+                        },
+                        None => {
+                            panic!("No config file specified.");
+                        }
                     }
+                    args_iter.next();
                     */
                 }
+                "--" => {
+                    // everything from here on out is a file
+                    for file in args_iter {
+                        files.push(file);
+                    }
+                    break;
+                }
                 _ => {
-                    files.push(arg);
+                    let mut arg_chars = arg.chars();
+                    if arg_chars.next() == Some('-') {
+                        for ch in arg_chars {
+                            match ch {
+                                'R' => {
+                                    unimplemented!();
+                                    /*
+                                    match editor.options.set("readonly") {
+                                        Ok(_) => debugln!(editor, "Set readonly mode"),
+                                        Err(_) => println!("Could not set readonly mode") 
+                                    }
+                                    */
+                                },
+                                'h' => {
+                                    println!("{}", HELP);
+                                    return;
+                                },
+                                _ => {
+                                    unimplemented!();
+                                }
+                            }
+                        }
+                    }
+
+                    files.push(arg.clone());
                 }
             }
         }

--- a/src/state/options.rs
+++ b/src/state/options.rs
@@ -20,7 +20,7 @@ impl Options {
             debug: true, // TODO: Let this be `true` only in debug compilation cfg
             highlight: true,
             line_marker: true,
-            readonly: true, // TODO: actually implement read-only mode
+            readonly: false,
         }
     }
 


### PR DESCRIPTION
I refactored the argument handling to allow for chaining of single option commands (-Cbx) etc., also adds read-only mode via -R argument.
