### PR TITLE
Fix a bug in insert_line

### DIFF
--- a/src/core/exec.rs
+++ b/src/core/exec.rs
@@ -70,7 +70,7 @@ impl Editor {
                     String::new()
                 };
                 let last = ind.len();
-                self.buffers.current_buffer_mut().insert_line(y, ind.into());
+                self.buffers.current_buffer_mut().insert_line(y + 1, ind.into());
                 self.goto((last, y + 1));
                 self.cursor_mut().mode =
                     Mode::Primitive(PrimitiveMode::Insert(InsertOptions {

--- a/src/edit/buffer.rs
+++ b/src/edit/buffer.rs
@@ -155,8 +155,8 @@ impl<'a> TextBuffer<'a> for SplitBuffer {
     fn insert_line(&mut self, n: usize, line: String) {
         if n < self.before.len() {
             self.before.insert(n, line);
-        } else if n < self.len() {
-            let n = self.len() - 1 - n;
+        } else if n <= self.len() {
+            let n = self.len() - n;
             self.after.insert(n, line);
         } else {
             panic!("Out of bound");

--- a/src/edit/insert.rs
+++ b/src/edit/insert.rs
@@ -38,7 +38,7 @@ impl Editor {
                 };
                 let begin = nl.len();
 
-                self.buffers.current_buffer_mut().insert_line(y, nl + &second_part);
+                self.buffers.current_buffer_mut().insert_line(y + 1, nl + &second_part);
 
                 self.redraw_task = RedrawTask::LinesAfter(y);
                 self.goto((begin, y + 1));


### PR DESCRIPTION
Assuming that `insert_line(n)` shall insert the string into nth-line (0 based).
- Fix a bug in insert_line when insert into after buffer
- Do corresponding changes in other place