### PR TITLE
Fix a panic when using 'dL' or 'dG'

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,8 @@
 Known bugs:
 
 - [x] When using `t` with a char that isn't in the document, Sodium will crash.
-- [x] `d<motion>` does not do anything if: 1) the motion moves to the end of a line. 2) if the motion moves to the last line.
+- [x] `dG` on the last line of the file deletes from the cursor to the end of the line, instead of the entire line.
+      Not sure if intended.
 
 The bug causing these two bugs, is localised to be in position.rs. It resolves by returning a value one over bound x
 

--- a/src/caret/motion.rs
+++ b/src/caret/motion.rs
@@ -62,7 +62,6 @@ impl Editor {
     pub fn to_motion_unbounded(&mut self, Inst(n, cmd): Inst) -> Option<(isize, isize)> {
         use io::key::Key::*;
 
-        let x = self.x();
         let y = self.y();
 
         match cmd.key {
@@ -71,8 +70,8 @@ impl Editor {
             Char('j') => Some(self.down_unbounded(n.d())),
             Char('k') => Some(self.up_unbounded(n.d())),
             Char('g') => Some((0, n.or(1) as isize - 1)),
-            Char('G') => Some((0, self.buffers.current_buffer().len() as isize - 1)),
-            Char('L') => Some(to_signed_pos((x, self.buffers.current_buffer()[y].len()))),
+            Char('G') => Some((self.buffers.current_buffer()[y].len() as isize, self.buffers.current_buffer().len() as isize - 1)),
+            Char('L') => Some(to_signed_pos((self.buffers.current_buffer()[y].len(), y))),
             Char('H') => Some((0, y as isize)),
             Char('t') => {
 

--- a/src/edit/buffer.rs
+++ b/src/edit/buffer.rs
@@ -146,7 +146,11 @@ impl<'a> TextBuffer<'a> for SplitBuffer {
             self.before.remove(n)
         } else if n < self.len() {
             let n = self.len() - 1 - n;
-            self.after.remove(n)
+            let ret = self.after.remove(n);
+            if n == 0 {
+                self.up();
+            }
+            ret
         } else {
             panic!("Out of bound");
         }

--- a/src/edit/selection.rs
+++ b/src/edit/selection.rs
@@ -7,8 +7,8 @@ impl Editor {
     /// defines a position on the same line, only the characters from the current position to the
     /// motion's position are removed.
     pub fn remove_rb<'a>(&mut self, (x, y): (isize, isize)) {
-        if y == self.y() as isize {
-            let (x, y) = self.bound((x as usize, y as usize), true);
+        if y == (self.y() as isize ) {
+            let (x, y) = self.bound((x as usize, y as usize), false);
             // Single line mode
             let (a, b) = if self.x() > x {
                 (x, self.x())


### PR DESCRIPTION
When using 'dG' while on the last line of a file, it now deletes from the cursor till the end of the line,
and **not** the entire line. Not sure what you had in mind for this.