### PR TITLE
infer file to save to from file opened

### DIFF
--- a/src/io/file.rs
+++ b/src/io/file.rs
@@ -37,8 +37,11 @@ impl Editor {
     }
 
     /// Write the file.
-    pub fn write(&mut self, path: &str) -> FileStatus {
+    pub fn write<'a> (&'a mut self, mut path: &'a str) -> FileStatus {
         self.buffers.current_buffer_info_mut().title = Some(path.into());
+        if path == "" {
+            path = self.files[0].as_str();
+        }
         if let Some(mut file) = File::create(path).ok() {
             if file.write(self.buffers.current_buffer().to_string().as_bytes())
                 .is_ok()

--- a/src/state/editor.rs
+++ b/src/state/editor.rs
@@ -185,6 +185,8 @@ pub struct Editor {
     pub char_width: usize,
     /// The character height in pixels
     pub char_height: usize,
+    /// The files currently open
+    pub files: Vec<String>,
 }
 
 impl Editor {
@@ -207,6 +209,7 @@ impl Editor {
             previous_instruction: None,
             char_width: 8,
             char_height: 16,
+            files: Vec::new(),
         };
 
         #[cfg(not(feature = "orbital"))]
@@ -221,6 +224,7 @@ impl Editor {
             previous_instruction: None,
             char_width: 8,
             char_height: 16,
+            files: Vec::new(),
         };
 
         let mut files: Vec<String> = Vec::new();
@@ -264,6 +268,7 @@ impl Editor {
                     for file in args_iter {
                         files.push(file);
                     }
+                    editor.files = files.clone();
                     break;
                 }
                 _ => {
@@ -291,6 +296,7 @@ impl Editor {
                     }
 
                     files.push(arg);
+                    editor.files = files.clone()
                 }
             }
         }


### PR DESCRIPTION
This allows `;w` to be run without any arguments and fixes #82 