### PR TITLE
Add bounds check to 'Z' command to prevent panic

### DIFF
--- a/src/core/exec.rs
+++ b/src/core/exec.rs
@@ -256,7 +256,9 @@ impl Editor {
                 self.redraw_task = RedrawTask::Full;
             }
             (Command(Normal), Char('Z')) => {
-                self.buffers.current_buffer_info_mut().scroll_y = self.y() - 3;
+                self.buffers.current_buffer_info_mut().scroll_y = if self.y() > 3 {
+                    self.y() - 3
+                } else { 0 };
                 self.redraw_task = RedrawTask::Full;
             }
             (Command(Normal), Char('~')) => {


### PR DESCRIPTION
Fixes panic described [here](https://gitlab.redox-os.org/redox-os/sodium/-/issues/37#note_8108)